### PR TITLE
make gauge map/list static

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ version_guice=4.1
 version_iep=1.0.4
 version_servo=0.12.17
 version_slf4j=1.7.25
-version_spectator=0.58.2
+version_spectator=0.60.0


### PR DESCRIPTION
This avoids them being eligible for GC prior to the value
of the gauge being sampled. See Netflix/spectator#506.